### PR TITLE
add options for href attribute and class names in tree nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,18 @@ The text value displayed for a given tree node.
 
 The icon displayed on a given node.
 
+#### href
+`String` `Optional`
+
+A custom `href` attribute value for a given node.
+
+#### class
+`String` `Optional`
+
+A class name or space separated list of class names to add to a given node.
+
+
+
 ## Options
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -78,8 +78,10 @@ var tree = [
         icon: "fa fa-folder",
         nodes: [
           {
-            text: "Sub Child Node 1",
-            icon: "fa fa-folder"
+            text:  "Sub Child Node 1",
+            icon:  "fa fa-folder",
+            class: "nav-level-3",
+            href:  "#option/1.1.1"
           },
           {
             text: "Sub Child Node 2",

--- a/dist/js/bstreeview.min.js
+++ b/dist/js/bstreeview.min.js
@@ -1,10 +1,14 @@
-/*! @preserve
- * bstreeview.js
- * Version: 0.0.1
- * Authors: Sami CHNITER <sami.chniter@gmail.com>
- * Copyright 2020
- * License: Apache License 2.0
- * 
- * Project: https://github.com/chniter/bstreeview
- */
-!function(t,e,i,s){"use strict";var n={expandIcon:"fa fa-angle-down",collapseIcon:"fa fa-angle-right",indent:1.25},a='<div href="#itemid" class="list-group-item" data-toggle="collapse"></div>',d='<div class="list-group collapse" id="itemid"></div>',o='<i class="state-icon"></i>',l='<i class="item-icon"></i>';function r(e,i){this.element=e,this.itemIdPrefix=e.id+"-item-",this.settings=t.extend({},n,i),this.init()}t.extend(r.prototype,{init:function(){this.tree=[],this.nodes=[],this.settings.data&&(this.settings.data=t.parseJSON(this.settings.data),this.tree=t.extend(!0,[],this.settings.data),delete this.settings.data),t(this.element).addClass("bstreeview"),this.initData({nodes:this.tree});var e=this;this.build(t(this.element),this.tree,0),t(".bstreeview").on("click",".list-group-item",function(){t(".state-icon",this).toggleClass(e.settings.expandIcon).toggleClass(e.settings.collapseIcon)})},initData:function(e){if(e.nodes){var i=e,s=this;t.each(e.nodes,function(t,e){e.nodeId=s.nodes.length,e.parentId=i.nodeId,s.nodes.push(e),e.nodes&&s.initData(e)})}},build:function(e,i,s){var n=this,r="1.25rem;";s>0&&(r=(n.settings.indent+s*n.settings.indent).toString()+"rem;"),s+=1,t.each(i,function(i,c){var h=t(a).attr("href","#"+n.itemIdPrefix+c.nodeId).attr("style","padding-left:"+r);if(c.nodes){var g=t(o).addClass(n.settings.collapseIcon);h.append(g)}if(c.icon){var p=t(l).addClass(c.icon);h.append(p)}if(h.append(c.text),e.append(h),c.nodes){var f=t(d).attr("id",n.itemIdPrefix+c.nodeId);e.append(f),n.build(f,c.nodes,s)}})}}),t.fn.bstreeview=function(e){return this.each(function(){t.data(this,"plugin_bstreeview")||t.data(this,"plugin_bstreeview",new r(this,e))})}}(jQuery,window,document);
+/*
+ @preserve
+ bstreeview.js
+ Version: 1.0.0
+ Authors: Sami CHNITER <sami.chniter@gmail.com>
+ Copyright 2020
+ License: Apache License 2.0
+
+ Project: https://github.com/chniter/bstreeview
+*/
+(function(a,m,n,p){function g(b,f){this.element=b;this.itemIdPrefix=b.id+"-item-";this.settings=a.extend({},l,f);this.init()}var l={expandIcon:"fa fa-angle-down",collapseIcon:"fa fa-angle-right",indent:1.25};a.extend(g.prototype,{init:function(){this.tree=[];this.nodes=[];this.settings.data&&(this.settings.data=a.parseJSON(this.settings.data),this.tree=a.extend(!0,[],this.settings.data),delete this.settings.data);a(this.element).addClass("bstreeview");this.initData({nodes:this.tree});var b=this;this.build(a(this.element),
+this.tree,0);a(".bstreeview").on("click",".list-group-item",function(){a(".state-icon",this).toggleClass(b.settings.expandIcon).toggleClass(b.settings.collapseIcon)})},initData:function(b){if(b.nodes){var f=this;a.each(b.nodes,function(a,c){c.nodeId=f.nodes.length;c.parentId=b.nodeId;f.nodes.push(c);c.nodes&&f.initData(c)})}},build:function(b,f,h){var c=this,g="1.25rem;";0<h&&(g=(c.settings.indent+h*c.settings.indent).toString()+"rem;");h+=1;a.each(f,function(f,d){var e=a('<div href="#itemid" class="list-group-item" data-toggle="collapse"></div>').attr("href",
+"#"+c.itemIdPrefix+d.nodeId).attr("style","padding-left:"+g);if(d.nodes){var k=a('<i class="state-icon"></i>').addClass(c.settings.collapseIcon);e.append(k)}d.icon&&(k=a('<i class="item-icon"></i>').addClass(d.icon),e.append(k));e.append(d.text);d.href&&e.attr("href",d.href);d["class"]&&e.addClass(d["class"]);b.append(e);d.nodes&&(e=a('<div class="list-group collapse" id="itemid"></div>').attr("id",c.itemIdPrefix+d.nodeId),b.append(e),c.build(e,d.nodes,h))})}});a.fn.bstreeview=function(b){return this.each(function(){a.data(this,
+"plugin_bstreeview")||a.data(this,"plugin_bstreeview",new g(this,b))})}})(jQuery,window,document);

--- a/src/js/bstreeview.js
+++ b/src/js/bstreeview.js
@@ -51,6 +51,7 @@
             this.nodes = [];
             // Retrieve bstreeview Json Data.
             if (this.settings.data) {
+                this.settings.data = $.parseJSON(this.settings.data);
                 this.tree = $.extend(true, [], this.settings.data);
                 delete this.settings.data;
             }
@@ -120,6 +121,17 @@
                 }
                 // Set node Text.
                 treeItem.append(node.text);
+
+                // Reset node href if present
+                if (node.href) {
+                    treeItem.attr('href', node.href);
+                }
+
+                // Add class to node if present
+                if (node.class) {
+                    treeItem.addClass(node.class);
+                }
+
                 // Attach node to parent.
                 parentElement.append(treeItem);
                 // Build child nodes.


### PR DESCRIPTION
+ this pull request fixes issue #5 
+ adds `href` to the options object (see issue #6 )
+ adds `class` to the options object in order to add one or more custom class names to a tree item as proposed in issue #5