### PR TITLE
Fix angle icon not toggling with two treeviews on a page

### DIFF
--- a/src/js/bstreeview.js
+++ b/src/js/bstreeview.js
@@ -62,7 +62,7 @@
             var _this = this;
             this.build($(this.element), this.tree, 0);
             // Update angle icon on collapse
-            $('.bstreeview').on('click', '.list-group-item', function () {
+            $(this.element).on('click', '.list-group-item', function () {
                 $('.state-icon', this)
                     .toggleClass(_this.settings.expandIcon)
                     .toggleClass(_this.settings.collapseIcon);


### PR DESCRIPTION
When you have two treeviews on a page, the icon no longer changes when you click on a folder, because the event handlers are being registered globally each time a bstreeview is created, and it toggles then toggles back. This patch fixes it.