### PR TITLE
Add the ability to specify whether a node should be initially expanded 

### DIFF
--- a/src/js/bstreeview.js
+++ b/src/js/bstreeview.js
@@ -126,7 +126,7 @@
                 // Set Expand and Collapse icones.
                 if (node.nodes) {
                     var treeItemStateIcon = $(templates.treeviewItemStateIcon)
-                        .addClass(_this.settings.collapseIcon);
+                        .addClass(node.expanded ? _this.settings.expandIcon : _this.settings.collapseIcon);
                     treeItem.append(treeItemStateIcon);
                 }
                 // set node icon if exist.
@@ -156,6 +156,10 @@
                     // Node group item.
                     var treeGroup = $(templates.treeviewGroupItem)
                         .attr('id', _this.itemIdPrefix + node.nodeId);
+                    // Expand the node if requested.
+                    if (node.expanded) {
+                        treeGroup.addClass('show');
+                    }
                     parentElement.append(treeGroup);
                     _this.build(treeGroup, node.nodes, depth);
                 }


### PR DESCRIPTION
First of all, thank you for the library!

This change allows the developer to chose whether a tree node should be expanded when the tree is initially shown. 
In order to do that do that, the developer should specify "expanded: true" in the JSON definition for the node.


