### PR TITLE
add support for Bootstrap 5

### DIFF
--- a/src/js/bstreeview.js
+++ b/src/js/bstreeview.js
@@ -1,6 +1,6 @@
 /*! @preserve
  * bstreeview.js
- * Version: 1.3.0
+ * Version: 1.2.0
  * Authors: Sami CHNITER <sami.chniter@gmail.com>
  * Copyright 2020
  * License: Apache License 2.0


### PR DESCRIPTION
This change  adds support to Bootstrap 5 (in addition to the existing support for Bootstrap 4). The attribute names (1) 'data-toggle' and 'data-bs-toggle' as well as (2) 'data-target' and 'data-bs-target' are supported based on the version of Bootstrap used.